### PR TITLE
node ca certs

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,6 +1,7 @@
 export STATIC_FILES_DIR="./test/test-static"
 export SKIP_AUTH=true
 export LOG_LEVEL=warning
+NODE_EXTRA_CA_CERTS=./test/rootCA.pem
 
 export PUBLIC_TEST_VAR="testvar"
 export PUBLIC_TESTING="testing"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,8 @@ updates:
       interval: "daily"
       time: "10:05"
       timezone: "Europe/Oslo"
+
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,4 +18,4 @@ jobs:
         run: bun run lint:ci
 
       - name: Tests
-        run: bun test
+        run: bun run test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-from oven/bun:1.1.22 as base
+from oven/bun:1.1.26 as base
 LABEL org.opencontainers.image.source="https://github.com/navikt/modia-frontend"
 LABEL org.opencontainers.image.description="BFF used in modia personoversikt"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-from oven/bun:1 as base
+from oven/bun:1.1.22 as base
 LABEL org.opencontainers.image.source="https://github.com/navikt/modia-frontend"
 LABEL org.opencontainers.image.description="BFF used in modia personoversikt"
 

--- a/client.js
+++ b/client.js
@@ -1,0 +1,2 @@
+const res = await fetch("https://localhost:9999/");
+console.log(await res.text());

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "module": "index.ts",
   "type": "module",
   "scripts": {
+    "test": "NODE_EXTRA_CA_CERTS='./test/rootCA.pem' bun test",
     "dev": "bun run --hot src/index.ts",
     "lint:js": "biome lint",
     "format-check": "biome format",

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -11,18 +11,6 @@ type ProxyHandler = {
   scope: string;
 };
 
-const tlsOptions = import.meta.env.NODE_EXTRA_CA_CERTS
-  ? {
-      ca: Bun.file(import.meta.env.NODE_EXTRA_CA_CERTS),
-    }
-  : undefined;
-
-// This function is here so we can inject a CA during tests
-const getTlsOptions = () =>
-  import.meta.env.NODE_ENV === "test" && import.meta.env.__TEST_EXTRA_CA_CERTS
-    ? { ca: Bun.file(import.meta.env.__TEST_EXTRA_CA_CERTS) }
-    : tlsOptions;
-
 const proxyHandlers: NonNullable<typeof fileConfig>["proxy"] =
   fileConfig?.proxy ?? {};
 
@@ -90,7 +78,6 @@ proxyApp.all("/:prefix/:path{.*}", async (c) => {
   );
 
   const res = await fetch(proxyRequest, {
-    tls: getTlsOptions(),
     redirect: "manual",
   });
 

--- a/test.ts
+++ b/test.ts
@@ -1,0 +1,10 @@
+import path from "node:path";
+
+Bun.serve({
+  port: 9999,
+  cert: Bun.file(path.join(import.meta.dir, "test", "localhost.pem")),
+  key: Bun.file(path.join(import.meta.dir, "test", "localhost-key.pem")),
+  fetch() {
+    return new Response("OK");
+  },
+});

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -118,11 +118,6 @@ describe("Proxy https with NODE_EXTRA_CA_CERTS", () => {
         return new Response("OK");
       },
     });
-
-    process.env.__TEST_EXTRA_CA_CERTS = path.join(
-      import.meta.dir,
-      "rootCA.pem",
-    );
   });
 
   it("Should work with custom CA certs", async () => {
@@ -130,10 +125,6 @@ describe("Proxy https with NODE_EXTRA_CA_CERTS", () => {
     const res = await app.fetch(req);
 
     expect(res.status).toBe(200);
-  });
-
-  afterAll(() => {
-    process.env.__TEST_EXTRA_CA_CERTS = undefined;
   });
 });
 


### PR DESCRIPTION
Bun teamet klarte å surre til releasen så 1.1.22 releasen inneholder ikke faktisk koden til 1.1.22,
og ikke denne fiksen, så denne PRen må ligge til de har fikset dette eller releaset en ny patch
versjon.

