### PR TITLE
Legg til referrer policy i secure headers

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -51,6 +51,9 @@ type ConfigFile = {
   disableCOOP: NonNullable<
     Parameters<typeof secureHeaders>[0]
   >["crossOriginOpenerPolicy"];
+  referrerPolicy:
+    | NonNullable<Parameters<typeof secureHeaders>[0]>["referrerPolicy"]
+    | undefined;
 };
 
 const loadConfigFile = async (): Promise<ConfigFile | undefined> => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,8 @@ app.use(
   secureHeaders({
     contentSecurityPolicy: fileConfig?.contentSecurityPolicy,
     crossOriginOpenerPolicy: !fileConfig?.disableCOOP,
+    referrerPolicy:
+      fileConfig?.referrerPolicy ?? "strict-origin-when-cross-origin",
   }),
 );
 


### PR DESCRIPTION
Setter `strict-origin-when-cross-origin` som default. Dette gjer at kun origin blir med på tvers av apper, men ikkje full path. Dvs at om det finnes sensitiv data i pathen så blir ikkje dette sendt.

Kan også endre config i modiapersonoversikt om ein vil overstyre defaulten.